### PR TITLE
Integrate separate FileUtils service

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/vascoferreira/cordova-plugin-filepath-generic.git"
+    "url": "https://github.com/Meeco/cordova-plugin-filepath-generic.git"
   },
   "keywords": [
     "cordova",
@@ -18,6 +18,6 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "author": "Vasco Ferreira <vascomferreira@gmail.com>",
-  "license": "Apache 2.0"
+  "author": "Meeco",
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "author": "Meeco",
-  "license": "MIT"
+  "author": "Vasco Ferreira <vascomferreira@gmail.com>",
+  "license": "Apache 2.0"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,8 +24,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <description>Cordova filepath generic plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova,file</keywords>
-    <repo>https://github.com/vascoferreira/cordova-plugin-filepath-generic.git</repo>
-    <issue>https://github.com/vascoferreira/cordova-plugin-filepath-generic/issues</issue>
+    <repo>https://github.com/Meeco/cordova-plugin-filepath-generic.git</repo>
+    <issue>https://github.com/Meeco/cordova-plugin-filepath-generic/issues</issue>
 
     <engines>
         <engine name="cordova-android" version=">=3.1.0" /><!-- Uses CordovaResourceApi -->
@@ -39,7 +39,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FilePath" >
-                <param name="android-package" value="com.vascoferreira.cordova.filepath.FilePath"/>
+                <param name="android-package" value="com.meeco.cordova.filepath.FilePath"/>
                 <param name="onload" value="true" />
             </feature>
         </config-file>
@@ -52,7 +52,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>
 
-        <source-file src="src/android/FilePath.java" target-dir="src/com/vascoferreira/cordova/filepath" />
+        <source-file src="src/android/FilePath.java" target-dir="src/com/meeco/cordova/filepath" />
+        <source-file src="src/android/FileUtils.java" target-dir="src/com/meeco/cordova/filepath" />
     </platform>
 
 </plugin>

--- a/src/android/FilePath.java
+++ b/src/android/FilePath.java
@@ -1,19 +1,10 @@
-package com.vascoferreira.cordova.filepath;
-
+package com.meeco.cordova.filepath;
 
 import android.Manifest;
-import android.content.ContentUris;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.provider.OpenableColumns;
 import android.util.Log;
-import android.database.Cursor;
-import android.os.Build;
-import android.os.Environment;
-import android.provider.ContactsContract;
-import android.provider.DocumentsContract;
-import android.provider.MediaStore;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -23,13 +14,6 @@ import org.apache.cordova.PermissionHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
-
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.List;
-import java.io.File;
-import java.util.Calendar;
-import java.io.ByteArrayInputStream;
 
 public class FilePath extends CordovaPlugin {
 
@@ -43,15 +27,15 @@ public class FilePath extends CordovaPlugin {
     private static final int GET_CLOUD_PATH_ERROR_CODE = 1;
     private static final String GET_CLOUD_PATH_ERROR_ID = "cloud";
 
-    private static final int RC_READ_EXTERNAL_STORAGE = 5;
-    
+    // private static final int RC_READ_EXTERNAL_STORAGE = 5;
+
     private static CallbackContext callback;
     private static String uriStr;
-    
+
     public static final int READ_REQ_CODE = 0;
-    
+
     public static final String READ = Manifest.permission.READ_EXTERNAL_STORAGE;
-    
+
     protected void getReadPermission(int requestCode) {
         PermissionHelper.requestPermission(this, requestCode, READ);
     }
@@ -85,7 +69,7 @@ public class FilePath extends CordovaPlugin {
         }
         else {
             JSONObject resultObj = new JSONObject();
-            
+
             resultObj.put("code", INVALID_ACTION_ERROR_CODE);
             resultObj.put("message", "Invalid action.");
 
@@ -94,7 +78,7 @@ public class FilePath extends CordovaPlugin {
 
         return false;
     }
-    
+
     public void resolveNativePath() throws JSONException {
         JSONObject resultObj = new JSONObject();
         /* content:///... */
@@ -103,7 +87,7 @@ public class FilePath extends CordovaPlugin {
         Log.d(TAG, "URI: " + this.uriStr);
 
         Context appContext = this.cordova.getActivity().getApplicationContext();
-        String filePath = getPath(appContext, pvUrl);
+        String filePath = FileUtils.getFileUrlForUri(appContext, pvUrl);
 
         //check result; send error/success callback
         if (filePath == GET_PATH_ERROR_ID) {
@@ -120,337 +104,25 @@ public class FilePath extends CordovaPlugin {
         }
         else {
             Log.d(TAG, "Filepath: " + filePath);
-
             this.callback.success("file://" + filePath);
         }
     }
-    
+
+
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
-        for (int r:grantResults) {
+        for (int r : grantResults) {
             if (r == PackageManager.PERMISSION_DENIED) {
                 JSONObject resultObj = new JSONObject();
                 resultObj.put("code", 3);
                 resultObj.put("message", "Filesystem permission was denied.");
-                
+
                 this.callback.error(resultObj);
                 return;
             }
         }
-        
+
         if (requestCode == READ_REQ_CODE) {
             resolveNativePath();
         }
-    }
-
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is ExternalStorageProvider.
-     */
-    private static boolean isExternalStorageDocument(Uri uri) {
-        return "com.android.externalstorage.documents".equals(uri.getAuthority());
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is DownloadsProvider.
-     */
-    private static boolean isDownloadsDocument(Uri uri) {
-        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is MediaProvider.
-     */
-    private static boolean isMediaDocument(Uri uri) {
-        return "com.android.providers.media.documents".equals(uri.getAuthority());
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is Google Photos.
-     */
-    private static boolean isGooglePhotosUri(Uri uri) {
-        return ("com.google.android.apps.photos.content".equals(uri.getAuthority())
-                || "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority()));
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is Google Drive.
-     */
-    private static boolean isGoogleDriveUri(Uri uri) {
-        return "com.google.android.apps.docs.storage".equals(uri.getAuthority()) || "com.google.android.apps.docs.storage.legacy".equals(uri.getAuthority());
-    }
-
-    /**
-     * Get the value of the data column for this Uri. This is useful for
-     * MediaStore Uris, and other file-based ContentProviders.
-     *
-     * @param context The context.
-     * @param uri The Uri to query.
-     * @param selection (Optional) Filter used in the query.
-     * @param selectionArgs (Optional) Selection arguments used in the query.
-     * @return The value of the _data column, which is typically a file path.
-     */
-    private static String getDataColumn(Context context, Uri uri, String selection,
-                                        String[] selectionArgs) {
-
-        Cursor cursor = null;
-        final String column = "_data";
-        final String[] projection = {
-                column
-        };
-
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                    null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int column_index = cursor.getColumnIndexOrThrow(column);
-                return cursor.getString(column_index);
-            }
-        } finally {
-            if (cursor != null)
-                cursor.close();
-        }
-        return null;
-    }
-
-    /**
-     * Get content:// from segment list
-     * In the new Uri Authority of Google Photos, the last segment is not the content:// anymore
-     * So let's iterate through all segments and find the content uri!
-     *
-     * @param segments The list of segment
-     */
-    private static String getContentFromSegments(List<String> segments) {
-        String contentPath = "";
-
-        for(String item : segments) {
-            if (item.startsWith("content://")) {
-                contentPath = item;
-                break;
-            }
-        }
-
-        return contentPath;
-    }
-
-    /**
-     * Check if a file exists on device
-     *
-     * @param filePath The absolute file path
-     */
-    private static boolean fileExists(String filePath) {
-        File file = new File(filePath);
-
-        return file.exists();
-    }
-
-    /**
-     * Get full file path from external storage
-     *
-     * @param pathData The storage type and the relative path
-     */
-    private static String getPathFromExtSD(String[] pathData) {
-        final String type = pathData[0];
-        final String relativePath = "/" + pathData[1];
-        String fullPath = "";
-
-        // on my Sony devices (4.4.4 & 5.1.1), `type` is a dynamic string
-        // something like "71F8-2C0A", some kind of unique id per storage
-        // don't know any API that can get the root path of that storage based on its id.
-        //
-        // so no "primary" type, but let the check here for other devices
-        if ("primary".equalsIgnoreCase(type)) {
-            fullPath = Environment.getExternalStorageDirectory() + relativePath;
-            if (fileExists(fullPath)) {
-                return fullPath;
-            }
-        }
-
-        // Environment.isExternalStorageRemovable() is `true` for external and internal storage
-        // so we cannot relay on it.
-        //
-        // instead, for each possible path, check if file exists
-        // we'll start with secondary storage as this could be our (physically) removable sd card
-        fullPath = System.getenv("SECONDARY_STORAGE") + relativePath;
-        if (fileExists(fullPath)) {
-            return fullPath;
-        }
-
-        fullPath = System.getenv("EXTERNAL_STORAGE") + relativePath;
-        if (fileExists(fullPath)) {
-            return fullPath;
-        }
-
-        return fullPath;
-    }
-
-    /**
-     * Get a file path from a Uri. This will get the the path for Storage Access
-     * Framework Documents, as well as the _data field for the MediaStore and
-     * other file-based ContentProviders.<br>
-     * <br>
-     * Callers should check whether the path is local before assuming it
-     * represents a local file.
-     *
-     * @param context The context.
-     * @param uri The Uri to query.
-     */
-    private static String getPath(final Context context, final Uri uri) {
-
-        Log.d(TAG, "File - " +
-                "Authority: " + uri.getAuthority() +
-                ", Fragment: " + uri.getFragment() +
-                ", Port: " + uri.getPort() +
-                ", Query: " + uri.getQuery() +
-                ", Scheme: " + uri.getScheme() +
-                ", Host: " + uri.getHost() +
-                ", Segments: " + uri.getPathSegments().toString()
-        );
-
-        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
-
-        // DocumentProvider
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            // ExternalStorageProvider
-            if (isExternalStorageDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                String fullPath = getPathFromExtSD(split);
-                if (fullPath != "") {
-                    return fullPath;
-                }
-                else {
-                    return null;
-                }
-            }
-            // DownloadsProvider
-            else if (isDownloadsDocument(uri)) {
-
-                final String id = DocumentsContract.getDocumentId(uri);
-                final Uri contentUri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-
-                return getDataColumn(context, contentUri, null, null);
-            }
-            // MediaProvider
-            else if (isMediaDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                Uri contentUri = null;
-                if ("image".equals(type)) {
-                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                } else if ("video".equals(type)) {
-                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                } else if ("audio".equals(type)) {
-                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                }
-
-                final String selection = "_id=?";
-                final String[] selectionArgs = new String[] {
-                        split[1]
-                };
-
-                return getDataColumn(context, contentUri, selection, selectionArgs);
-            }
-            else if(isGoogleDriveUri(uri)){
-                return getDriveFilePath(uri,context);
-            }
-        }
-        // MediaStore (and general)
-        else if ("content".equalsIgnoreCase(uri.getScheme())) {
-            if (uri.toString().contains("contact") &&  uri.toString().endsWith("photo")) {
-                return getContactPhotoDriveFilePath(uri, context);
-            }
-            return getDriveFilePath(uri,context);
-        }
-        // File
-        else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
-        }
-
-        return null;
-    }
-
-    private static String getContactPhotoDriveFilePath(Uri uri,Context context){
-        Uri returnUri =uri;
-        Cursor returnCursor = context.getContentResolver().query(returnUri, new String[] {ContactsContract.Contacts.Photo.PHOTO}, null, null, null);
-        int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-        returnCursor.moveToFirst();
-        byte[] data = returnCursor.getBlob(0);
-        String name = "tempFile" + Calendar.getInstance().getTimeInMillis();
-        if (nameIndex>=0) {
-            name = (returnCursor.getString(nameIndex));
-        }
-        File   file = new File(context.getCacheDir(),name);
-        try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-            FileOutputStream outputStream = new FileOutputStream(file);
-            int read = 0;
-            int maxBufferSize = 1 * 1024 * 1024;
-            int  bytesAvailable = inputStream.available();
-
-            //int bufferSize = 1024;
-            int bufferSize = Math.min(bytesAvailable, maxBufferSize);
-
-            final byte[] buffers = new byte[bufferSize];
-            while ((read = inputStream.read(buffers)) != -1) {
-                outputStream.write(buffers, 0, read);
-            }
-            Log.e("File Size","Size " + file.length());
-            inputStream.close();
-            outputStream.close();
-            Log.e("File Path","Path " + file.getPath());
-            Log.e("File Size","Size " + file.length());
-        }catch (Exception e){
-            Log.e("Exception",e.getMessage());
-        }
-        return  file.getPath();
-    }
-
-    private static String getDriveFilePath(Uri uri,Context context){
-        Uri returnUri =uri;
-        Cursor returnCursor = context.getContentResolver().query(returnUri, null, null, null, null);
-        /*
-        * Get the column indexes of the data in the Cursor,
-        *     * move to the first row in the Cursor, get the data,
-        *     * and display it.
-        * */
-        int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-        int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
-        returnCursor.moveToFirst();
-        String name = (returnCursor.getString(nameIndex));
-        String size = (Long.toString(returnCursor.getLong(sizeIndex)));
-        File   file = new File(context.getCacheDir(),name);
-        try {
-            InputStream inputStream = context.getContentResolver().openInputStream(uri);
-            FileOutputStream outputStream = new FileOutputStream(file);
-            int read = 0;
-            int maxBufferSize = 1 * 1024 * 1024;
-            int  bytesAvailable = inputStream.available();
-
-            //int bufferSize = 1024;
-            int bufferSize = Math.min(bytesAvailable, maxBufferSize);
-
-            final byte[] buffers = new byte[bufferSize];
-            while ((read = inputStream.read(buffers)) != -1) {
-                outputStream.write(buffers, 0, read);
-            }
-            Log.e("File Size","Size " + file.length());
-            inputStream.close();
-            outputStream.close();
-            Log.e("File Path","Path " + file.getPath());
-            Log.e("File Size","Size " + file.length());
-        }catch (Exception e){
-            Log.e("Exception",e.getMessage());
-        }
-        return  file.getPath();
     }
 }

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -1,0 +1,245 @@
+/**
+ * Copy of https://github.com/ionic-team/capacitor/blob/main/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+ * with slight modifications
+ */
+
+package com.meeco.cordova.filepath;
+
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * Common File utilities, such as resolve content URIs and
+ * creating portable web paths from low-level files
+ */
+public class FileUtils {
+
+    private static final String TAG = "[FilePath plugin]: ";
+
+    public static String getFileUrlForUri(final Context context, final Uri uri) {
+        // DocumentProvider
+        if (DocumentsContract.isDocumentUri(context, uri)) {
+            Log.d(TAG, "#DocumentsContract.isDocumentUri = true");
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                } else {
+                    final int splitIndex = docId.indexOf(':', 1);
+                    final String tag = docId.substring(0, splitIndex);
+                    final String path = docId.substring(splitIndex + 1);
+
+                    String nonPrimaryVolume = getPathToNonPrimaryVolume(context, tag);
+                    if (nonPrimaryVolume != null) {
+                        String result = nonPrimaryVolume + "/" + path;
+                        File file = new File(result);
+                        if (file.exists() && file.canRead()) {
+                            return result;
+                        }
+                        return null;
+                    }
+                }
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+                Log.d(TAG, "#isDownloadsDocument = true");
+
+                String path = null;
+
+                try {
+                    // Sometimes id is not just a number. Example: msf:25651
+                    final String id = DocumentsContract.getDocumentId(uri);
+                    final Uri contentUri = ContentUris.withAppendedId(Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                    path = getDataColumn(context, contentUri, null, null);
+                } catch (Exception e) {
+                    Log.e(TAG, e.getMessage());
+                }
+
+                // Customized: if nothing above matches, try to copy file to cache
+                if (path == null) {
+                    Log.d(TAG, "Fallback to #getCopyFilePath");
+                    path = getCopyFilePath(uri, context);
+                }
+
+                return path;
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                Log.d(TAG, "#isMediaDocument = true");
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] { split[1] };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            } else {
+                // Customized: if nothing above matches, try to copy file to cache
+                Log.d(TAG, "Document type not identified. Fallback to #getCopyFilePath");
+                return getCopyFilePath(uri, context);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            Log.d(TAG, "content:// protocol detected");
+            // Return the remote address
+            if (isGooglePhotosUri(uri)) return uri.getLastPathSegment();
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            Log.d(TAG, "file:// protocol detected");
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    private static String getDataColumn(Context context, Uri uri, String selection, String[] selectionArgs) {
+        String path = null;
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = { column };
+
+        Log.d(TAG, "#getDataColumn");
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                path = cursor.getString(index);
+            }
+        } catch (IllegalArgumentException ex) {
+            Log.e("Exception", ex.getMessage());
+            return getCopyFilePath(uri, context);
+        } finally {
+            if (cursor != null) cursor.close();
+        }
+        if (path == null) {
+            return getCopyFilePath(uri, context);
+        }
+        return path;
+    }
+
+    private static String getCopyFilePath(Uri uri, Context context) {
+        Log.d(TAG, "#getCopyFilePath");
+
+        Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
+        int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+        cursor.moveToFirst();
+        String name = (cursor.getString(nameIndex));
+        // Customized, previously getDataDir was used
+        File cacheDir = new File(context.getCacheDir() + "/filepath_resolver_cache", UUID.randomUUID().toString());
+        cacheDir.mkdirs();
+        File file = new File(cacheDir, name);
+        try {
+            InputStream inputStream = context.getContentResolver().openInputStream(uri);
+            FileOutputStream outputStream = new FileOutputStream(file);
+            int read = 0;
+            int maxBufferSize = 1024 * 1024;
+            int bufferSize = Math.min(inputStream.available(), maxBufferSize);
+            final byte[] buffers = new byte[bufferSize];
+            while ((read = inputStream.read(buffers)) != -1) {
+                outputStream.write(buffers, 0, read);
+            }
+            inputStream.close();
+            outputStream.close();
+        } catch (Exception e) {
+            Log.e("Exception", e.getMessage());
+            return null;
+        } finally {
+            if (cursor != null) cursor.close();
+        }
+        return file.getPath();
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+
+    private static String getPathToNonPrimaryVolume(Context context, String tag) {
+        Log.d(TAG, "#getPathToNonPrimaryVolume");
+
+        File[] volumes = context.getExternalCacheDirs();
+
+        if (volumes != null) {
+            for (File volume : volumes) {
+                if (volume != null) {
+                    String path = volume.getAbsolutePath();
+                    if (path != null) {
+                        int index = path.indexOf(tag);
+                        if (index != -1) {
+                            return path.substring(0, index) + tag;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Changes:
- Imported FileUtils service from https://github.com/ionic-team/capacitor/blob/main/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
- Replace previous resolver logic with the imported one
- FileUtils service modified to fallback to creating a copy of a file in app cache directory if something unexpected happens

Tested on Android Pixel 2 API 28 emulator and OnePlus 6 (Android version 10).